### PR TITLE
Enabling testing for a pointer that references a nonexistent value ex…

### DIFF
--- a/src/main/java/com/github/fge/jsonpatch/TestOperation.java
+++ b/src/main/java/com/github/fge/jsonpatch/TestOperation.java
@@ -33,7 +33,7 @@ import com.google.common.base.Equivalence;
  * to test ({@code path}) and the value to test equality against ({@code
  * value}).</p>
  *
- * <p>It is an error if no value exists at the given path.</p>
+ * <p>It is an error if no value exists at the given path and there is an expected value to test equality against.</p>
  *
  * <p>Also note that equality as defined by JSON Patch is exactly the same as it
  * is defined by JSON Schema itself. As such, this operation reuses {@link
@@ -57,10 +57,11 @@ public final class TestOperation
         throws JsonPatchException
     {
         final JsonNode tested = path.path(node);
-        if (tested.isMissingNode())
+
+        if (tested.isMissingNode() && !value.isNull())
             throw new JsonPatchException(BUNDLE.getMessage(
                 "jsonPatch.noSuchPath"));
-        if (!EQUIVALENCE.equivalent(tested, value))
+        if (!(tested.isMissingNode() && value.isNull()) && !EQUIVALENCE.equivalent(tested, value))
             throw new JsonPatchException(BUNDLE.getMessage(
                 "jsonPatch.valueTestFailure"));
         return node.deepCopy();

--- a/src/test/resources/jsonpatch/test.json
+++ b/src/test/resources/jsonpatch/test.json
@@ -14,6 +14,11 @@
             "op": { "op": "test", "path": "/x", "value": -30.000 },
             "node": { "x": -29.020 },
             "message": "jsonPatch.valueTestFailure"
+        },
+        {
+            "op": { "op": "test", "path": "/a/1", "value": null },
+            "node": { "a": [ null, "hello", "world" ] },
+            "message": "jsonPatch.valueTestFailure"
         }
     ],
     "ops": [
@@ -26,6 +31,11 @@
             "op": { "op": "test", "path": "/a/1", "value": "hello" },
             "node": { "a": [ null, "hello", "world" ] },
             "expected": { "a": [ null, "hello", "world" ] }
+        },
+        {
+            "op": { "op": "test", "path": "/x", "value": null },
+            "node": 1.00,
+            "expected": 1.00
         }
     ]
 }


### PR DESCRIPTION
We are trying to write a JSON Patch _test_ operation that asserts the value at a path is not set. 

Per the "Error Handling" section of the [RFC on JSON Pointers](https://tools.ietf.org/html/rfc6901#section-7):
> Error conditions include, but are not limited to:
> * Invalid pointer syntax
> * A pointer that references a nonexistent value
>
> This specification does not define how errors are handled.  An application of JSON Pointer SHOULD specify the impact and handling of each type of error. 
> 
> For example, some applications might stop pointer processing upon an error, while others may attempt to recover from missing values by inserting default ones.

A JSON Patch _test_ operation can only test that evaluating a JSON pointer results in a specified value. I would like to consider that processing a JSON Pointer for the application of a JSON Patch _test_ operation would evaluate a nonexistent value as null, at least when comparing to null. 

